### PR TITLE
[-] MO : compareProducts not assigned in ajax

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -3061,6 +3061,7 @@ class BlockLayered extends Module
 				'static_token' => Tools::getToken(false),
 				'page_name' => 'category',
 				'nArray' => $nArray,
+				'compareProducts' => CompareProduct::getCompareProducts((int)$this->context->cookie->id_compare)
 			)
 		);
 		


### PR DESCRIPTION
When using block layered, the variable compareProducts was not passed to Smarty and disallow us from using the product comparator : checkboxes were obviously never checked. Just added one line in the Smarty assign.

This bug exists for many years and is pretty annoying ! Please consider merging fast, thanks.
