### PR TITLE
Fix legend NULL if multiple images

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -1997,7 +1997,7 @@ class BlockLayered extends Module
 			'.Shop::addSqlAssociation('product', 'p').'
 			'.Product::sqlStock('p', null, false, Context::getContext()->shop).'
 			LEFT JOIN '._DB_PREFIX_.'product_lang pl ON (pl.id_product = p.id_product'.Shop::addSqlRestrictionOnLang('pl').' AND pl.id_lang = '.(int)$cookie->id_lang.')
-			LEFT JOIN `'._DB_PREFIX_.'image` i  ON (i.`id_product` = p.`id_product`)'.
+			LEFT JOIN `'._DB_PREFIX_.'image` i  ON (i.`id_product` = p.`id_product` AND i.`cover` = 1)'.
 			Shop::addSqlAssociation('image', 'i', false, 'image_shop.cover=1').'
 			LEFT JOIN `'._DB_PREFIX_.'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = '.(int)$cookie->id_lang.')
 			LEFT JOIN '._DB_PREFIX_.'manufacturer m ON (m.id_manufacturer = p.id_manufacturer)


### PR DESCRIPTION
Legend is NULL when a product has more than one image and that the cover is not the first one.
