### PR TITLE
Redundant call of $this->getSelectedFilters()

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -3002,7 +3002,7 @@ class BlockLayered extends Module
 		global $smarty, $cookie;
 
 		$selected_filters = $this->getSelectedFilters();
-		$filter_block = $this->getFilterBlock($this->getSelectedFilters());
+		$filter_block = $this->getFilterBlock($selected_filters);
 		$this->getProducts($selected_filters, $products, $nb_products, $p, $n, $pages_nb, $start, $stop, $range);
 		
 		// Add pagination variable


### PR DESCRIPTION
the return array for $this->getSelectedFilters() is saved the line before, no need to call it a second time
