### PR TITLE
Update blocklayered.php price rounding

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -1304,8 +1304,8 @@ class BlockLayered extends Module
 				$values[] = '('.(int)$id_product.',
 					'.(int)$currency['id_currency'].',
 					'.$id_shop.',
-					'.(int)$min_price[$currency['id_currency']].',
-					'.(int)Tools::ps_round($max_price[$currency['id_currency']] * (100 + $max_tax_rate) / 100, 0).')';
+					'.(int)floor($min_price[$currency['id_currency']] * ((100 + $max_tax_rate) / 100)).',
+					'.(int)ceil($max_price[$currency['id_currency']] * ((100 + $max_tax_rate) / 100)).')';
 			
 			Db::getInstance()->execute('
 				INSERT INTO `'._DB_PREFIX_.'layered_price_index` (id_product, id_currency, id_shop, price_min, price_max)


### PR DESCRIPTION
The lower price bound was without tax included (if applicable), and doesn't round to nearest integer. I've found that having the lower bound round down, and the upper bound rounding up works perfectly for filtering by price, unlike before. In certain circumstances, products would appear in wrong price filters. I've been using this code for two months now, and have always found it to work as intended.
