### PR TITLE
 Blocklayered shows product combinations not in stock.

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -1869,6 +1869,7 @@ class BlockLayered extends Module
 						LEFT JOIN `'._DB_PREFIX_.'product_attribute` pa
 						ON (pa.`id_product_attribute` = pac.`id_product_attribute`)'.
 						Shop::addSqlAssociation('product_attribute', 'pa').'
+						INNER JOIN `ps_stock_available` sa ON (sa.id_product_attribute = pa.id_product_attribute AND sa.id_shop = ' . Context::getContext()->shop->id . ' AND sa.quantity > 0)
 						WHERE '.implode(' OR ', $sub_query).') ';
 					}
 				break;


### PR DESCRIPTION
Blocklayered is showing product combinations with quantity = 0 when a user filters on a product attribute group.
The problem appears when the product has a positive quantity for a product attribute even if we are filtering on another product attribute which has zero quantity on the stock_available.
