### PR TITLE
Select field "change" event in place of "click"

### DIFF
--- a/blocklayered.js
+++ b/blocklayered.js
@@ -42,11 +42,15 @@ $(document).ready(function()
 		reloadContent(true);
 	});
 
-	$(document).on('click', '#layered_form .select, #layered_form input[type=checkbox], #layered_form input[type=radio]', function(e) {
+	$(document).on('click', '#layered_form input[type=checkbox], #layered_form input[type=radio]', function(e) {
 
 		reloadContent(true);
 	});
-
+	
+	$(document).on('change', '#layered_form .select', function(e) {
+		reloadContent(true);
+	});
+	
 	// Changing content of an input text
 	$(document).on('keyup', '#layered_form input.layered_input_range', function(e)
 	{


### PR DESCRIPTION
Select fields change event should be used rather the click event, as this causes a bug on browsers and the contents gets refreshed before a user have swlected anything from the drop down list to filter.