### PR TITLE
FIX for multi-store configuration where Shop from normal Context doesn't work.

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -64,7 +64,11 @@ class BlockLayered extends Module
 		{
 			if (version_compare(_PS_VERSION_, '1.6.0', '>=') === true)
 			{
-				// Hook the module either on the left or right column
+                // Get Shop ID from selected Context
+                $id_shop_context = (int)Context::getContext()->shop->getContextShopID();
+                $shop = new Shop($id_shop_context);
+
+                // Hook the module either on the left or right column
 				$theme = new Theme(Context::getContext()->shop->id_theme);
 				if ((!$theme->default_left_column || !$this->registerHook('leftColumn'))
 					&& (!$theme->default_right_column || !$this->registerHook('rightColumn')))

--- a/blocklayered.php
+++ b/blocklayered.php
@@ -64,11 +64,7 @@ class BlockLayered extends Module
 		{
 			if (version_compare(_PS_VERSION_, '1.6.0', '>=') === true)
 			{
-                // Get Shop ID from selected Context
-                $id_shop_context = (int)Context::getContext()->shop->getContextShopID();
-                $shop = new Shop($id_shop_context);
-
-                // Hook the module either on the left or right column
+				// Hook the module either on the left or right column
 				$theme = new Theme(Context::getContext()->shop->id_theme);
 				if ((!$theme->default_left_column || !$this->registerHook('leftColumn'))
 					&& (!$theme->default_right_column || !$this->registerHook('rightColumn')))

--- a/blocklayered.php
+++ b/blocklayered.php
@@ -64,8 +64,12 @@ class BlockLayered extends Module
 		{
 			if (version_compare(_PS_VERSION_, '1.6.0', '>=') === true)
 			{
-				// Hook the module either on the left or right column
-				$theme = new Theme(Context::getContext()->shop->id_theme);
+                // Get Shop ID from selected Context
+                $id_shop_context = (int)Context::getContext()->shop->getContextShopID();
+                $shop = new Shop($id_shop_context);
+
+                // Hook the module either on the left or right column
+				$theme = new Theme($shop->id_theme);
 				if ((!$theme->default_left_column || !$this->registerHook('leftColumn'))
 					&& (!$theme->default_right_column || !$this->registerHook('rightColumn')))
 				{


### PR DESCRIPTION
FIX for multi-store configuration where Shop from normal Context doesn't work.
When you have a multi-store configuration, the `Context::getContext()->shop->id_theme` does not give you the id_theme, because of the multi-store configuration. First get the correct shop from the `getContextShopID()`

