### PR TITLE
[*] MO: allow override

### DIFF
--- a/blocklayered-ajax.php
+++ b/blocklayered-ajax.php
@@ -26,8 +26,7 @@
 
 include(dirname(__FILE__).'/../../config/config.inc.php');
 include(dirname(__FILE__).'/../../init.php');
-include(dirname(__FILE__).'/blocklayered.php');
 
 Context::getContext()->controller->php_self = 'category';
-$blockLayered = new BlockLayered();
+$blockLayered = Module::getInstanceByName('blocklayered');
 echo $blockLayered->ajaxCall();


### PR DESCRIPTION
Module::getInstanceByName takes into account the override methods. If we just use "new" overrided methods won't work on ajax calls

merge at the same time as this PR: https://github.com/PrestaShop/blocklayered/pull/48