### PR TITLE
Dev

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -37,7 +37,7 @@ class BlockLayered extends Module
 	{
 		$this->name = 'blocklayered';
 		$this->tab = 'front_office_features';
-		$this->version = '2.0.8';
+		$this->version = '2.0.9';
 		$this->author = 'PrestaShop';
 		$this->need_instance = 0;
 		$this->bootstrap = true;


### PR DESCRIPTION
How does the fact that in my version (the latest) the order of filters back each time in the default order when I want to edit and change?

Before save
![bug2](https://cloud.githubusercontent.com/assets/7002732/7322104/30cae5f2-eaa6-11e4-9ccc-86d7df1e44c8.png)

After save when I edit :
![bug](https://cloud.githubusercontent.com/assets/7002732/7322072/fda20ed0-eaa5-11e4-878d-89bed0a8e513.png)

I have to put them in the right order each time you change the filters. How can I resolve this bug please?