### PR TITLE
[-] MO : Removed SQL-code which does not seem to serve any purpose wh…

### DIFF
--- a/blocklayered.php
+++ b/blocklayered.php
@@ -1814,9 +1814,7 @@ class BlockLayered extends Module
 				ON p.id_product = cp.id_product
 				INNER JOIN '._DB_PREFIX_.'category c ON (c.id_category = cp.id_category AND
 				c.nleft >= '.(int)$parent->nleft.' AND c.nright <= '.(int)$parent->nright.'
-				AND c.active = 1)
-				RIGHT JOIN '._DB_PREFIX_.'layered_category lc ON (lc.id_category = '.(int)$id_parent.' AND
-				lc.id_shop = '.(int) Context::getContext()->shop->id.')';
+				AND c.active = 1)';
 			else
 				$query_filters_from .= ' INNER JOIN '._DB_PREFIX_.'category_product cp
 				ON p.id_product = cp.id_product


### PR DESCRIPTION
On our implementation of PrestaShop we are having a serious performance issue related to the category pages. These pages take about 4 to 16 seconds to load. 

There are more people having the same issue.
https://www.prestashop.com/forums/topic/199619-layered-navigation-block-performance-issue/

The drop in performance is caused by the query for selecting the product ID's. There is a right join in it which does not seem to serve any purpose but which is causing MySQL to create temp tables for storing intermediate results. I removed the right join and checked if the returned rows were still the same, which indeed was the case. The query then took less than 0.02 secs to complete.

Hope this update can be included!
