### PR TITLE
Update blocklayered_admin.js

### DIFF
--- a/js/blocklayered_admin.js
+++ b/js/blocklayered_admin.js
@@ -206,6 +206,8 @@ $(document).ready(
 		if (typeof filters !== 'undefined')
 		{
 			filters = JSON.parse(filters);
+			var filtertmp = [];
+			var filteri = 0;
 
 			for (filter in filters)
 			{
@@ -213,6 +215,13 @@ $(document).ready(
 				$('#selected_filters').html(parseInt($('#selected_filters').html())+1);
 				$('select[name="'+filter+'_filter_type"]').val(filters[filter].filter_type);
 				$('select[name="'+filter+'_filter_show_limit"]').val(filters[filter].filter_show_limit);
+				var elt = document.getElementById(filter);
+				var eltli = elt.parentNode.parentNode.parentNode; /* the LI */
+				var eltul = elt.parentNode.parentNode.parentNode.parentNode; /* the UL */
+				filtertmp[filteri++] = eltul.removeChild(eltli);
+			}
+			for(var i=0; i<filteri; i++)
+			{	eltul.appendChild(filtertmp[i]);
 			}
 		}
 	}


### PR DESCRIPTION
A known bug of blocklayered is that it doesn't hold a changed order of the filters. You can drag and drop the lines in the backoffice and it will work. However, when you re-open the filter-template it will show you the elements in the original order. Saving that order will undo your sorting. See for example https://www.prestashop.com/forums/topic/317265-layered-navigation-block-dont-keep-order-position/ and https://www.prestashop.com/forums/topic/336943-layered-navigation-block-filters-order/). This modification repairs that problem. 

As Prestashop saves only positions of the active filters in this template we can only reconstruct those. I have implemented it at the end of the filter list. At the beginning would be an alternative option.

I have made the modification so that only blocklayered_admin.js is changed. For clarity it would probably be better when more files are changed: neither the form nor the UL and LI elements of the list have at the moment an id or a name that would make it possible to address them directly.
