### PR TITLE
Missing AJAX parameter added to query

### DIFF
--- a/blocklayered.js
+++ b/blocklayered.js
@@ -414,7 +414,7 @@ function reloadContent(params_plus)
 	{
 		type: 'GET',
 		url: baseDir + 'modules/blocklayered/blocklayered-ajax.php',
-		data: data+params_plus+n,
+		data: data+params_plus+n+'&ajax',
 		dataType: 'json',
 		cache: false, // @todo see a way to use cache and to add a timestamps parameter to refresh cache each 10 minutes for example
 		success: function(result)


### PR DESCRIPTION
There should always be an ajax parameter in the ajax request uri, to set $context->controller->ajax properly and to enable other modules to identify request as ajax request.
