### PR TITLE
Fix JavaScript mistake in blocklayered.js

### DIFF
--- a/blocklayered.js
+++ b/blocklayered.js
@@ -397,7 +397,7 @@ function reloadContent(params_plus)
 	}
 	
 	var slideUp = true;
-	if (params_plus == undefined || !(typeof params_plus == 'string'))
+	if (typeof params_plus === 'undefined' || !(typeof params_plus == 'string'))
 	{
 		params_plus = '';
 		slideUp = false;


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof):

```
The typeof operator returns a string indicating the type of the unevaluated operand.
```

So checking a variable as `=== undefined` is a mistake.
